### PR TITLE
Add conversion of slack emoji encoding

### DIFF
--- a/bin/wordle_decoder
+++ b/bin/wordle_decoder
@@ -10,8 +10,18 @@ CLI::UI::StdoutRouter.enable
 
 print CLI::UI.fmt("\n  Share your wordle:\n\n{{blue:>}} ")
 
+def convert_slack(line)
+  subs = {
+    ":black_large_square:" => "⬛",
+    ":white_large_square:" => "⬜",
+    ":large_green_square:" => "🟩",
+    ":large_yellow_square:" => "🟨",
+  }
+  subs.reduce(line) { |acc, (key, val)| acc.gsub(key, val) }
+end
+
 input_lines = []
-until WordleDecoder::WordleShare.final_line?(input_line = gets)
+until WordleDecoder::WordleShare.final_line?(input_line = convert_slack(gets))
   input_lines << input_line
   if WordleDecoder::WordleShare.exit_program?(input_line)
     puts "\n  Goodbye!\n\n"


### PR DESCRIPTION
When pasting from Slack, the characters are converted to ascii aliases, e.g. `:green_large_square:` instead of 🟩. This adds a quick wrapper function to do those string replacements. 